### PR TITLE
[30기 박별] Fix : subnav 분리완료

### DIFF
--- a/src/components/Subnav/Subnav.js
+++ b/src/components/Subnav/Subnav.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import './Subnav.scss';
+
+function Subnav() {
+  return (
+    <div className="sub-nav">
+      <div className="inner">
+        <a href="#">상품소개</a>
+        <a href="#">선물세트</a>
+        <a href="#">이벤트</a>
+        <input type="text" placeholder="검색어를 입력해주세요." />
+        <i className="fa fa-search" aria-hidden="true" />
+      </div>
+    </div>
+  );
+}
+
+export default Subnav;

--- a/src/components/Subnav/Subnav.scss
+++ b/src/components/Subnav/Subnav.scss
@@ -1,0 +1,52 @@
+@charset 'utf-8';
+
+.sub-nav {
+  width: 100%;
+  height: 40px;
+  background-color: #f4f4f4;
+  position: fixed;
+  top: 55px;
+  z-index: 9999;
+
+  .inner {
+    max-width: 1180px;
+    display: flex;
+    justify-content: right;
+    align-items: center;
+    margin: 0 auto;
+    margin-right: 145px;
+
+    a {
+      color: #707070;
+      margin: -1px 20px 0;
+      font-size: 15px;
+      text-decoration: none;
+      line-height: 45px;
+
+      &:hover {
+        transition: 0.5s;
+        color: #f4bb5f;
+      }
+    }
+
+    input {
+      width: 198px;
+      height: 25px;
+      border: none;
+      border-radius: 5px;
+      margin: -1px 12px 0;
+      padding: 0 0 0 10px;
+
+      &::placeholder {
+        padding: 0 0 0 10px;
+        font-size: 11px;
+        color: #b2b2b2;
+      }
+    }
+
+    .fa-search {
+      font-size: 15px;
+      color: #9b9b9b;
+    }
+  }
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 로그인 페이지를 제외한 나머지 페이지에서는 nav밑에 subnav가 존재합니다. 그렇기에 그 페이지에서 사용할 수 있도록 nav와 마찬가지로 스크롤을 내리더라도 메뉴가 함께 따라 내려올 수 있게 구현하는 것이 목표입니다.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. subnav 구현하기 (프론트)
- subnav가 스크롤을 내려도 같이 따라내려오게 하기 위해서 position:fixed;와 컨텐츠에 가려지지않도록 z-index값을 줬습니다.
- 역시나 각각의 메뉴에 마우스를 올렸을 때, 색이 들어올 수 있도록, transition을 주어서 색이 천천히 올라올 수 있도록 구현했습니다. 
- 검색도 할 수 있도록, input창을 만들어서 구현했습니다.


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- position으로 설정해주니, 밑에 있는 컨텐츠들이 메뉴를 인식하지 못하고 위로 올라와서 margin-top값을 주어 해결했습니다.
- git에 subnav 브랜치에 넣지 않고 login 브랜치에서 작업해서 다시 일일이 작업하는 것에 번거로움을 느꼈습니다. 하지만, 그 결과 많이 미숙했던 git 다루는 게 지금은 좀 익숙해진 느낌이 들어서 전화위복이 된 것 같습니다. 

<br />

## :: 기타 질문 및 특이 사항
- 메뉴에 있는 페이지를 각각 누를 때마다 색이 각각에 맞게 들어오게 만들고 싶습니다. 리액트를 어떻게 이용하면 가능할지 조금.. 감이 오지 않습니다! 어떻게 하면 가능할까요..? 
